### PR TITLE
Update to portainer-ce image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
 
   portainer:
     container_name: portainer
-    image: portainer/portainer:latest
+    image: portainer/portainer-ce:latest
     restart: always
     depends_on:
       - traefik


### PR DESCRIPTION
Original portainer image was EOL. Updated to portainer-ce latest. 

When going from 1.24.x the update worked without issue to the portainer DB. YMMV